### PR TITLE
Add mode designation to template of credentials

### DIFF
--- a/tasks/aws_credentials.yml
+++ b/tasks/aws_credentials.yml
@@ -6,4 +6,4 @@
 - name: AWS CLI | Create config
   sudo: yes
   sudo_user: "{{ aws_config_user }}"
-  template: src=config.j2 dest="~/.aws/config"
+  template: src=config.j2 dest="~/.aws/config" mode=0640


### PR DESCRIPTION
Files were able to be templated as world-readable (0644). Adding mode of 0640 to this task makes the secret AWS credentials not world-readable.
